### PR TITLE
Update addressable gem to 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.2.5
+- Update addressable gem to 2.8
+
 ## Version 0.2.4
 - Increase minimum Decidim version to v0.23.0
 - Add decidim_version in `lib/decidim/verifications/barcelona_energia_census/version.rb`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       tzinfo (~> 1.1)
     acts_as_list (0.9.19)
       activerecord (>= 3.0)
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     anchored (1.1.0)
     arel (9.0.0)

--- a/lib/decidim/verifications/barcelona_energia_census/version.rb
+++ b/lib/decidim/verifications/barcelona_energia_census/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module Verifications
     module BarcelonaEnergiaCensus
       def self.version
-        '0.2.4'
+        '0.2.5'
       end
 
       def self.decidim_version


### PR DESCRIPTION
To solve GHSA-jxhc-q857-3j6g which is CVE-2021-32740.